### PR TITLE
Security fix for Command Injection in changelogx

### DIFF
--- a/lib/git-helper.js
+++ b/lib/git-helper.js
@@ -1,9 +1,9 @@
-const _exec = require('child_process').exec;
+const _exec = require('child_process').execFile;
 const extend = require('extend');
 
-const exec = (cmd, cb) =>
+const exec = (cmd, args, cb) =>
   _exec(
-    cmd,
+    cmd, args,
     {
       maxBuffer: Infinity,
     },
@@ -39,7 +39,7 @@ const validateTags = (tags, range) => {
 module.exports = {
   getTags(opts) {
     return new Promise((resolve, reject) => {
-      exec("git for-each-ref --sort=taggerdate --format '%(tag)'", (err, stdout /* , stderr */) => {
+      exec("git", ["for-each-ref", "--sort=taggerdate", "--format", "'%(tag)'"], (err, stdout /* , stderr */) => {
         if (!err) {
           let tags = stdout
             .split('\n')
@@ -79,12 +79,13 @@ module.exports = {
     let range = opts.from ? `${opts.from}..` : '';
     range += opts.to;
 
-    const gitCmd = `git log ${opts.args} ${range}`;
+    const gitCmd = `git`;
+    const gitArgs = [`log`,`${opts.args}`, `${range}`];
 
     const parseLog = require('./log-parser');
 
     return new Promise((resolve, reject) => {
-      exec(gitCmd, (err, stdout) => {
+      exec(gitCmd, gitArgs, (err, stdout) => {
         if (!err) {
           const commits = parseLog(stdout, {
             ignoreRegExp,


### PR DESCRIPTION
### 📊 Metadata *

The git_helper.getCommits() function in changelogx package that expects to execute git log command can be illegally injected arbitrary other OS commands by its $range arguments.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-changelogx/

### ⚙️ Description *

Using execFile() to replace exec().

### 💻 Technical Description *

The use of the child_process function exec() is highly discouraged if you accept user input and don't sanitize/escape them. This PR replaces it with execFile() which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

// PoC.sh
npm i changelogx -g

git clone https://github.com/royriojas/changelogx.git
cd changelogx

ls 
#you cannot see pzhou@shu
changelogx -r '1.0..;$(touch pzhou@shu)' -o changelog.html
ls 
#you can see pzhou@shu

### 🔥 Proof of Fix (PoF) *

After fix, running ``changelogx -r '1.0..;$(touch pzhou@shu)' -o changelog.html`` cannot illegally create the file pzhou@shu.

### 👍 User Acceptance Testing (UAT)

 changelogx -h
Usage: changelogx [install-hook] [options]

Options:
  -f, --format String            Use a specific output format, markdown or html. - either: html or markdown - default: html
  -p, --tagPrefix String         The tag prefix to filter the tags obtained from git.
  -r, --tagRange String          Filter the commits to only the ones between the given tag range
  -o, --outputFile path::String  Specify file to write the changelog to. If omitted the output will be printed to the stdout. IF this option is set no other logs will print to stdout (-q is implicit here)
  -m, --maxSubjectLength Number  If the command install-hook is used, this option allows to specify the maximum length for the commit subject - default: 140
  -i, --ignoreRegExp [String]    A regular expression to match for commits that should be ignored from the changelog
  -h, --help                     Show this help
  -v, --version                  Outputs the version number
  -q, --quiet                    Show only the summary info - default: false
  --colored-output               Use colored output in logs
  --stack                        if true, uncaught errors will show the stack trace if available
  -c, --config String            Path to your `changelogx` config. By Default will look for a `changelogx` section on your `package.json`

When no configuration is provided, some defaults based on your `package.json` file will be used. For Example:

"changelogx": {
  "ignoreRegExp": ["BLD: Release", "DOC: Generate Changelog", "Generated Changelog"],
  "issueIDRegExp" : "#(\\d+)",
  "commitURL": "https://github.com/$user$/changelogx/commit/{0}",
  "authorURL": "https://github.com/{0}",
  "issueIDURL": "https://github.com/$user$/changelogx/issues/{0}",
  "projectName": "changelogx"
}

### 🔗 Relates to...

https://www.huntr.dev/bounties/1-npm-changelogx/
